### PR TITLE
Test codespace

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -8,6 +8,8 @@ COPY requirements.txt requirements_docs.txt /tmp/
 
 RUN conda init bash
 
+RUN apt update && apt install -y azcopy
+
 RUN source /opt/conda/etc/profile.d/conda.sh && \
     conda activate base && \
     pip install --no-cache-dir -r /tmp/requirements.txt

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 //
 {
   "name": "nextflow-training",
-  "image": "ghcr.io/nextflow-io/training:3.5",
+  "image": "ghcr.io/biosustain/dsp_course_proteomics_intro:sha-6a49cae",
   "workspaceFolder": "/workspaces/dsp_course_proteomics_intro",
   "remoteUser": "root",
   "remoteEnv": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 //
-// MAIN PRODUCTION DEVCONTAINER CONFIG
+// MAIN PRODUCTION DEVCONTAINER CONFIG for Seqera trainings
 // Uses image that is pre-built and pushed to GitHub
 // See .github/.devcontainer/devcontainer.json for build
+// Augmented using Dockerfile.
 //
 {
   "name": "nextflow-training",
@@ -12,10 +13,11 @@
     // Nextflow installation version
     "NXF_HOME": "/workspaces/.nextflow",
     "NXF_EDGE": "0",
-    "NXF_VER": "24.10.6",
+    "NXF_VER": "25.10.4",
+    // "NXF_SYNTAX_PARSER": "v2",
     // Other env vars
     "HOST_PROJECT_PATH": "/workspaces/dsp_course_proteomics_intro",
-    "SHELL": "/bin/bash" // Ush bash
+    "SHELL": "/bin/bash" // Use bash
   },
   "onCreateCommand": "bash .devcontainer/setup.sh",
   "customizations": {

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -14,7 +14,7 @@
     "NXF_HOME": "/workspaces/.nextflow",
     "NXF_EDGE": "0",
     "NXF_VER": "25.10.4",
-    // "NXF_SYNTAX_PARSER": "v2",
+    "NXF_SYNTAX_PARSER": "v1",
     // Other env vars
     "HOST_PROJECT_PATH": "/workspaces/dsp_course_proteomics_intro",
     "SHELL": "/bin/bash" // Use bash

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -6,7 +6,7 @@
 //
 {
   "name": "nextflow-training",
-  "image": "ghcr.io/biosustain/dsp_course_proteomics_intro:sha-6a49cae",
+  "image": "ghcr.io/biosustain/dsp_course_proteomics_intro:sha-1d18359",
   "workspaceFolder": "/workspaces/dsp_course_proteomics_intro",
   "remoteUser": "root",
   "remoteEnv": {

--- a/.devcontainer/setup.sh
+++ b/.devcontainer/setup.sh
@@ -15,3 +15,10 @@ conda activate base
 # pip install gdown
 # python 0_download_PXD040621_data.py
 pip install -r requirements.txt
+
+# sudo apt update
+# sudo apt install -y azcopy
+
+azcopy copy \
+"https://dspteaching.blob.core.windows.net/msdatasets/PXD040621/mzML/*?sp=rwl&st=2026-05-29T10:56:55Z&se=2026-06-05T15:11:55Z&spr=https&sv=2026-02-06&sr=d&sig=gCopwuxco%2F8LQRohxJhxATxLszTnMSxpt%2B9gLA0KajU%3D&sdd=2" \
+"/workspaces/dsp_course_proteomics_intro/data/PXD040621/mzML"

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -2,12 +2,12 @@ name: publish-docker-image
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - "v*"
-  pull_request:
+  #   branches:
+  #     - main
+  # pull_request:
   workflow_dispatch:
+  release:
+    types: [published]
 
 permissions:
   contents: read

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,7 @@
 name: publish-docker-image
 
 on:
-  push:
+  # push:
   #   branches:
   #     - main
   # pull_request:

--- a/material/instructions_quantms_PXD04621.md
+++ b/material/instructions_quantms_PXD04621.md
@@ -13,6 +13,22 @@ Use the following link to open a GitHub codespace with most of the required soft
 
 ## Download the data
 
+### Option 1: Open in Codespace
+
+> Will only work during the course. You do not to do anything.
+
+We are using a setup script in `.devcontainer/setup.sh` to download the data from 
+Azure Blob Storage using [azcopy](https://learn.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10).
+Access to the data is restricted during the time of the course only.
+
+### Option 2: Git LFS
+
+> Could be added to git LFS storage via GitHub, but the billing is uncertain.
+
+### Option 3: OneDrive Options
+
+> If you want to run it outside of the setting of this course
+
 Currently the data is stored on a
 [Google Drive folder](https://drive.google.com/drive/folders/1gxUh9nMx9icFLrI0vn3zAB9dDjZf-1Nh).
 It should be downloaded when you run the tutorial in a GitHub codespace automatically.
@@ -30,9 +46,9 @@ python 0_download_PXD040621_data.py
 ## Run the analysis
 
 ```bash
-# export NXF_VER=24.10.6
+# export NXF_VER=25.10.4
 nextflow run bigbio/quantms \
-         -revision 1.5.0 \
+         -revision 1.7.0 \
          -params-file PXD040621_w_contaminants-params.yaml \
          -profile docker \
          -resume
@@ -41,9 +57,9 @@ nextflow run bigbio/quantms \
 If you run **locally on a Mac with Apple Silicion (M-ships)**, you need to addtionally the `arm` profile:
 
 ```bash
-# export NXF_VER=24.10.6
+# export NXF_VER=25.10.4
 nextflow run bigbio/quantms \
-         -revision 1.5.0 \
+         -revision 1.7.0 \
          -params-file PXD040621_w_contaminants-params.yaml \
          -profile docker,arm \
          -resume


### PR DESCRIPTION
This pull request updates the development environment and documentation for the proteomics training course, focusing on improving data download automation, updating the base image and Nextflow version, and clarifying instructions for users. The main changes include switching to a new Docker image, automating data download with `azcopy`, and updating Nextflow and pipeline versions in the documentation.

**Development environment updates:**

* Changed the base image in `.devcontainer/devcontainer.json` to `ghcr.io/biosustain/dsp_course_proteomics_intro:sha-6a49cae` and updated the workspace folder to match the new course repository.
* Updated the default Nextflow version to `25.10.4` and enabled the new syntax parser via `NXF_SYNTAX_PARSER`.
* Installed `azcopy` in the Dockerfile to enable automated data downloads from Azure Blob Storage.

**Data download automation:**

* Modified `.devcontainer/setup.sh` to automatically download the required dataset using `azcopy` during the container setup process.
* Updated the instructions in `material/instructions_quantms_PXD04621.md` to explain the automated data download via Codespace and `azcopy`, and clarified alternative options for obtaining the data.

**Documentation and pipeline updates:**

* Updated the recommended Nextflow and pipeline versions in the analysis instructions to `25.10.4` and `1.7.0`, respectively, for both standard and Apple Silicon workflows. [[1]](diffhunk://#diff-37c53854084739a25a6c5b080aee6563f113f76dc84426689ab5a0976729e6cbL33-R51) [[2]](diffhunk://#diff-37c53854084739a25a6c5b080aee6563f113f76dc84426689ab5a0976729e6cbL44-R62)